### PR TITLE
ZCL9 - Global + Basic cluster

### DIFF
--- a/Basic.xml
+++ b/Basic.xml
@@ -15,7 +15,7 @@ applicable to this document can be found in the LICENSE.md file.
   <classification role="utility" picsCode="B" />
   <server>
     <attributes>
-      <attribute id="0000" name="ZCLVersion" type="uint8" required="true" max="255" default="8" />
+      <attribute id="0000" name="ZCLVersion" type="uint8" required="true" max="255" default="9" />
       <attribute id="0001" name="ApplicationVersion" type="uint8" max="255" default="0" />
       <attribute id="0002" name="StackVersion" type="uint8" max="255" default="0" />
       <attribute id="0003" name="HWVersion" type="uint8" max="255" default="0" />

--- a/global.xml
+++ b/global.xml
@@ -167,8 +167,8 @@
   </type:type>
 
   <attributes>
-    <attribute id="fffd" name="ClusterRevision" type="uint16" min="1" max="65534" required="true"
-      default="revision()" />
+    <attribute id="fffc" name="FeatureMap" type="map32" min="0" max="4294967295" required="true" default="0" />
+    <attribute id="fffd" name="ClusterRevision" type="uint16" min="1" max="65534" required="true" default="revision()" />
     <attribute id="fffe" name="AttributeReportingStatus" type="enum8">
       <restriction>
         <type:enumeration value="00" name="Pending" />


### PR DESCRIPTION
ZCL9 update:
- New Global attribute FeatureMap which applies to any cluster
- Basic Cluster update revision of ZCL default mandatory